### PR TITLE
Chore: Automate generation of database password and encryption key in Terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,11 +81,17 @@ resource "google_sql_database" "n8n_database" {
 resource "google_sql_user" "n8n_user" {
   name     = var.db_user
   instance = google_sql_database_instance.n8n_db_instance.name
-  password = var.db_password
+  password = random_password.db_password.result
   project  = var.gcp_project_id
 }
 
 # --- Secret Manager --- #
+# Generate a random password for the DB
+resource "random_password" "db_password" {
+  length  = 16
+  special = true
+}
+
 resource "google_secret_manager_secret" "db_password_secret" {
   secret_id = "${var.cloud_run_service_name}-db-password"
   project   = var.gcp_project_id
@@ -97,9 +103,14 @@ resource "google_secret_manager_secret" "db_password_secret" {
 
 resource "google_secret_manager_secret_version" "db_password_secret_version" {
   secret      = google_secret_manager_secret.db_password_secret.id
-  secret_data = var.db_password
+  secret_data = random_password.db_password.result
 }
 
+# Secret Manager: n8n encryption key
+resource "random_password" "n8n_encryption_key" {
+  length  = 32
+  special = true
+}
 resource "google_secret_manager_secret" "encryption_key_secret" {
   secret_id = "${var.cloud_run_service_name}-encryption-key"
   project   = var.gcp_project_id
@@ -111,7 +122,7 @@ resource "google_secret_manager_secret" "encryption_key_secret" {
 
 resource "google_secret_manager_secret_version" "encryption_key_secret_version" {
   secret      = google_secret_manager_secret.encryption_key_secret.id
-  secret_data = var.n8n_encryption_key
+  secret_data = random_password.n8n_encryption_key.result
 }
 
 # --- IAM Service Account & Permissions --- #

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -88,8 +88,12 @@ resource "google_sql_user" "n8n_user" {
 # --- Secret Manager --- #
 # Generate a random password for the DB
 resource "random_password" "db_password" {
-  length  = 16
-  special = true
+  length      = 16
+  special     = true
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
   keepers = {
     db_instance = google_sql_database_instance.n8n_db_instance.name
     db_user     = var.db_user

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -90,6 +90,10 @@ resource "google_sql_user" "n8n_user" {
 resource "random_password" "db_password" {
   length  = 16
   special = true
+  keepers = {
+    db_instance = google_sql_database_instance.n8n_db_instance.name
+    db_user     = var.db_user
+  }
 }
 
 resource "google_secret_manager_secret" "db_password_secret" {
@@ -109,7 +113,7 @@ resource "google_secret_manager_secret_version" "db_password_secret_version" {
 # Secret Manager: n8n encryption key
 resource "random_password" "n8n_encryption_key" {
   length  = 32
-  special = true
+  special = false
 }
 resource "google_secret_manager_secret" "encryption_key_secret" {
   secret_id = "${var.cloud_run_service_name}-encryption-key"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,18 +1,14 @@
 # Example terraform.tfvars file
 # Rename this to terraform.tfvars and fill in the sensitive values.
 
-# --- Required --- #
-db_password        = "YOUR_SECURE_DB_PASSWORD"
-n8n_encryption_key = "YOUR_VERY_LONG_RANDOM_ENCRYPTION_KEY"
-
 # --- Optional (Defaults are likely suitable based on your setup) --- #
-# gcp_project_id = "allie-n8n"
+# gcp_project_id = "your-project-id"
 # gcp_region     = "us-west2"
 # db_name        = "n8n"
 # db_user        = "n8n-user"
 # db_tier        = "db-f1-micro"
 # db_storage_size = 10
-# artifact_repo_name = "allie-n8n"
+# artifact_repo_name = "n8n-repo"
 # cloud_run_service_name = "n8n"
 # service_account_name = "n8n-service-account"
 # cloud_run_cpu = "2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,18 +22,6 @@ variable "db_user" {
   default     = "n8n-user"
 }
 
-variable "db_password" {
-  description = "Password for the Cloud SQL database user. Will be stored in Secret Manager."
-  type        = string
-  sensitive   = true
-}
-
-variable "n8n_encryption_key" {
-  description = "Encryption key for n8n. Will be stored in Secret Manager."
-  type        = string
-  sensitive   = true
-}
-
 variable "db_tier" {
   description = "Cloud SQL instance tier."
   type        = string


### PR DESCRIPTION
### Description

- Replaced static variables for `db_password` and `n8n_encryption_key` with automatically generated random values using the `random_password` Terraform resource.
- Updated Cloud SQL user and Secret Manager resources to use generated passwords/keys instead of relying on sensitive input variables.
- Removed `db_password` and `n8n_encryption_key` from both `variables.tf` and `terraform.tfvars.example`.
- Simplified and secured the Terraform configuration for database and application key management.

### Rationale

- Enhances security by avoiding hard-coded secrets and manual secret management.
- Reduces the risk of accidental exposure of sensitive values in version control or configuration files.
- Streamlines the setup and maintenance process for new deployments.

### Significant Changes

- **main.tf**
  - Added `random_password` resources for DB password and n8n encryption key.
  - Updated resource references to use generated secrets.
- **variables.tf**
  - Removed `db_password` and `n8n_encryption_key` variables.
- **terraform.tfvars.example**
  - Removed sensitive variables fields from the example file and updated repo name to match with manual steps